### PR TITLE
Fix `ReferenceError: path is not defined`

### DIFF
--- a/lib/tempfile.coffee
+++ b/lib/tempfile.coffee
@@ -2,6 +2,7 @@ TempfileView = require './tempfile-view'
 util = require './tempfile-util'
 {CompositeDisposable} = require 'atom'
 
+path = require 'path'
 tmp = require 'tmp'
 
 module.exports = Tempfile =


### PR DESCRIPTION
**Atom Version**: 1.9.9
**System**: Mac OS X 10.11.6
**Thrown From**: [tempfile](https://github.com/fkfk/atom-tempfile) package, v0.3.0
### Stack Trace

Failed to activate the tempfile package

```
At path is not defined

ReferenceError: path is not defined
    at Object.module.exports.Tempfile.activate (/Users/kachick/.atom/packages/tempfile/lib/tempfile.coffee:13:51)
    at Package.module.exports.Package.activateNow (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:183:20)
    at /Applications/Atom.app/Contents/Resources/app.asar/src/package.js:795:25
    at Function.module.exports.Emitter.simpleDispatch (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/event-kit/lib/emitter.js:25:14)
    at Emitter.module.exports.Emitter.emit (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/event-kit/lib/emitter.js:125:28)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:241:20)
    at /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:3:61
    at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:580:16)
    at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:388:22)
    at WindowEventHandler.module.exports.WindowEventHandler.handleDocumentKeyEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:98:36)
    at HTMLDocument.<anonymous> (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:3:61)
```
### Commands

```
     -0:00.0 tempfile:create (atom-text-editor.editor.is-focused)
```
