### PR TITLE
Fix extentions if nothing the configration

### DIFF
--- a/lib/tempfile-util.coffee
+++ b/lib/tempfile-util.coffee
@@ -18,7 +18,7 @@ module.exports = TempfileUtil =
     fs.normalize tempPath
 
   getExtension: (grammar) ->
-    extensions = _.deepExtend {}, @extensions, atom.config.get "tempfile-extra"
+    extensions = _.deepExtend {}, @extensions, atom.config.get("tempfile-extra") || {}
     return undefined unless grammar and typeof extensions is "object"
     extensions[grammar.scopeName]
 


### PR DESCRIPTION
Atom Version: 1.9.9
System: Mac OS X 10.11.6
Thrown From: tempfile package, v0.3.1

When I have no configuration around any file type as

``` cson
'tempfile-extra':
  'source.perl': 'pl6'
```

Then it does not attach file extensions to anywhere.
